### PR TITLE
Support draft1 set for the gerrit inline edit

### DIFF
--- a/add_reviewer.py
+++ b/add_reviewer.py
@@ -146,11 +146,16 @@ if __name__ == "__main__":
             break
         try:
             data = json.loads(line)
-            if data['type'] != 'patchset-created':
+            if data['type'] != 'draftset-created':
+                continue
+            elif data['type'] != 'patchset-created':
                 continue
             change = data['change']
             patchset = data['patchSet']
-            if int(patchset['number']) != 1:
+            draftset = data['draftSet']
+            if int(draftset['number']) != 1:
+                continue
+            elif int(patchset['number']) != 1:
                 continue
 
             owner = change['owner']['name'].lower()

--- a/pop3bot.py
+++ b/pop3bot.py
@@ -70,13 +70,17 @@ def get_changeset(changeid, o=['CURRENT_REVISION', 'CURRENT_FILES', 'DETAILED_AC
 def new_changeset_generator(mailbox):
     for mail in gerritmail_generator(mailbox):
         mt = mail.get('X-Gerrit-MessageType', '')
+        d = mail.get('Gerrit-DraftSet', '')
         ps = mail.get('Gerrit-PatchSet', '')
         commit = mail['X-Gerrit-Commit']
 
         if mt != 'newchange':
             print "skipping message (%s)" % mt
             continue
-        if ps != '1':
+        if d != '1':
+            print "skipping Draft%s" % ps
+            continue
+        elif ps != '1':
             print "skipping PS%s" % ps
             continue
         print "(getting ", commit, ")"


### PR DESCRIPTION
We wont need the draft view setting for this bot so it shoulden be able to read any drafts.

This is for when it is published for everyone through the gerrit inline edit, it does Draft1 if you do publish straight away with no edits.
