### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    open-pull-requests-limit: 2
+    directory: "/"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
- add a dependabot config which checks pip dependencies
- limit to 2 PRs open at a time
- ignore patch-level updates